### PR TITLE
Fix contempt value scaling

### DIFF
--- a/asmFish/guts/Think.asm
+++ b/asmFish/guts/Think.asm
@@ -423,8 +423,13 @@ GD_NewLine
 		mov   edx, dword[rbp+Pos.gamePly]
 	       call   TimeMng_Init
 
+		mov   eax, dword[options.contempt]
+		cdq
+	       imul   eax, PawnValueEg
+		mov   ecx, 100
+	       idiv   ecx
+		mov   ecx, eax
 		mov   eax, dword[rbp+Pos.sideToMove]
-		mov   ecx, dword[options.contempt]
 		neg   ecx
 		mov   dword[DrawValue+4*rax], ecx
 		xor   eax, 1


### PR DESCRIPTION
Scale contempt value to centipawns the same way Stockfish does.
Thanks to Stefan Pohl for reporting the issue.