### PR TITLE
2016-12-17 Another simplification for SEE pruning

### DIFF
--- a/asmFish/guts/SearchMacros.asm
+++ b/asmFish/guts/SearchMacros.asm
@@ -1074,14 +1074,7 @@ end if
 		jge   .13done
 		cmp   byte[.extension], 0
 		jne   .13done
-	       imul   edx, edx
-	       imul   edx, -35
-
-	if .PvNode eq 1
-		sub   edx, 300
-	else
-		sub   edx, 400
-	end if
+	       imul   edx, -PawnValueEg
 
 	       call   SeeTest
 	       test   eax, eax

--- a/asmFish/guts/Uci.asm
+++ b/asmFish/guts/Uci.asm
@@ -104,7 +104,7 @@ UciNextCmdFromCmdLine:
 		mov   rsi, r15
 	       test   r15, r15
 		jnz   UciChoose
-		jmp   UciGetInput
+		jmp   UciQuit
 
 UciWriteOut_NewLine:
        PrintNewLine

--- a/asmFish/guts/asmFish.asm
+++ b/asmFish/guts/asmFish.asm
@@ -235,7 +235,7 @@ end if
 if USE_BOOK
 	db 'option name OwnBook type check default false'
 	NewLineData
-	db 'option name BookPath type string default <empty>'
+	db 'option name BookFile type string default <empty>'
 	NewLineData
 end if
 


### PR DESCRIPTION
This pull request also contains a little change in Uci.asm making asmFish behave like Stockfish:
"When called with some command line arguments, e.g. to run 'bench', once the command is executed the function returns immediately." (comment from Stockfish:Uci.cpp)
This bug prevented scripts like BuildTester from working. See: http://www.talkchess.com/forum/viewtopic.php?topic_view=threads&p=698075&t=62416
