### PR TITLE
dont clobber eax when testing checkers

### DIFF
--- a/asmFish/guts/PosIsDrawMacro.asm
+++ b/asmFish/guts/PosIsDrawMacro.asm
@@ -61,8 +61,8 @@ coldreturnlabel:
 
 ; this macro should be headed by the coldlabel argument of the PosIsDraw macro
 macro PosIsDraw_Cold WeHaveADraw, coldreturnlabel {
-		mov   rax, qword[rbx+State.checkersBB]
-	       test   rax, rax
+		mov   r11, qword[rbx+State.checkersBB]	; don't clobber eax
+	       test   r11, r11				; as it holds ply 
 		 jz   WeHaveADraw
 	       push   rax rcx rdx r8 r9 rdi
 		mov   rdi, qword[rbx-1*sizeof.State+State.endMoves]


### PR DESCRIPTION
To see this small bug, you would need a position that has
50 move count >= 100
and we are in check
and we have no legal moves

I think this means we are checkmated.
Why does stockfish fall though in this case?