### PR TITLE
fix two bugs in draw detection

### DIFF
--- a/asmFish/guts/PosIsDrawMacro.asm
+++ b/asmFish/guts/PosIsDrawMacro.asm
@@ -61,8 +61,8 @@ coldreturnlabel:
 
 ; this macro should be headed by the coldlabel argument of the PosIsDraw macro
 macro PosIsDraw_Cold WeHaveADraw, coldreturnlabel {
-		mov   rax, qword[rbx+State.checkersBB]
-	       test   rax, rax
+		mov   r11, qword[rbx+State.checkersBB]	; don't clobber eax
+	       test   r11, r11				; as it holds ply 
 		 jz   WeHaveADraw
 	       push   rax rcx rdx r8 r9 rdi
 		mov   rdi, qword[rbx-1*sizeof.State+State.endMoves]

--- a/asmFish/guts/PosIsDrawMacro.asm
+++ b/asmFish/guts/PosIsDrawMacro.asm
@@ -63,12 +63,12 @@ coldreturnlabel:
 macro PosIsDraw_Cold WeHaveADraw, coldreturnlabel {
 		mov   r11, qword[rbx+State.checkersBB]	; don't clobber eax
 	       test   r11, r11				; as it holds ply 
-		 jz   WeHaveADraw
+		 jz   WeHaveADraw		; draw if we are not in check
 	       push   rax rcx rdx r8 r9 rdi
 		mov   rdi, qword[rbx-1*sizeof.State+State.endMoves]
 	       call   Gen_Legal
 		cmp   rdi, qword[rbx-1*sizeof.State+State.endMoves]
 		pop   rdi r9 r8 rdx rcx rax
-		 je   WeHaveADraw
-		jmp   coldreturnlabel
+		jne   WeHaveADraw		; draw if we have some moves
+		jmp   coldreturnlabel		; otherwise fall through
 }


### PR DESCRIPTION
The second bug was caused by confusing c++ syntactics. Apparently
`(!checkers() || MoveList<LEGAL>(*this).size())`
means we have a draw if
 we are not in check
 or we do have some legal moves

Assuming the second bug fix, the first bug was caused by clobbering eax.
You will notice this in positions that have
 50 move count >= 100
 and we are in check
 and we have no legal moves
This is checkmate and stockfish doesn't immediately report draw in this case.

Note that the second bug has been present in asmFish ab initio, which tells you just how cold this code is.