### PR TITLE
Capture Stat Simplification-

### DIFF
--- a/x86/Evaluate_Init.asm
+++ b/x86/Evaluate_Init.asm
@@ -78,11 +78,6 @@ Evaluate_Init:
 	      stosq
 
 
-                lea   rsi, [.PawnsSet]
-                lea   rdi, [PawnsSet]
-                mov   ecx, 9
-          rep movsd
-
                 lea   rsi, [.QueenMinorsImbalance]
                 lea   rdi, [QueenMinorsImbalance]
                 mov   ecx, 16
@@ -295,9 +290,6 @@ Evaluate_Init:
  dd 0
 
 
-
-.PawnsSet:
-        dd 24, -32, 107, -51, 117, -9, -126, -21, 31
 
 .QueenMinorsImbalance:
         dd 31, -8, -15, -25, -5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0

--- a/x86/MainBss.asm
+++ b/x86/MainBss.asm
@@ -127,7 +127,6 @@ PassedFile                 rd 8
 DoMaterialEval_Data:
 .QuadraticOurs:            rd 8*6
 .QuadraticTheirs:          rd 8*6
-PawnsSet                   rd 16
 QueenMinorsImbalance       rd 16
 
 

--- a/x86/SearchMacros.asm
+++ b/x86/SearchMacros.asm
@@ -1511,9 +1511,9 @@ Display 2, "Search returning %i0%n"
           movzx   ecx, byte[rbp+Pos.board+rax]
             shl   ecx, 6
             lea   r15d, [rax+rcx]
+    ; r15d = offset of [piece_on(prevSq),prevSq]
            test   dl, dl
             jnz   .ReturnTTValue_UpdateStatsDone
-    ; r15d = offset of [piece_on(prevSq),prevSq]
     UpdateStats   r12d, 0, 0, r11d, r10d, r15
 .ReturnTTValue_UpdateStatsDone:
             mov   eax, edi

--- a/x86/SearchMacros.asm
+++ b/x86/SearchMacros.asm
@@ -1511,13 +1511,10 @@ Display 2, "Search returning %i0%n"
           movzx   ecx, byte[rbp+Pos.board+rax]
             shl   ecx, 6
             lea   r15d, [rax+rcx]
-    ; r15d = offset of [piece_on(prevSq),prevSq]
            test   dl, dl
-            jnz   .ReturnTTValue_UpdateCaptureStats
+            jnz   .ReturnTTValue_UpdateStatsDone
+    ; r15d = offset of [piece_on(prevSq),prevSq]
     UpdateStats   r12d, 0, 0, r11d, r10d, r15
-            jmp   .ReturnTTValue_UpdateStatsDone
-.ReturnTTValue_UpdateCaptureStats:
-    UpdateCaptureStats  r12d, 0, 0, r11d, r10d
 .ReturnTTValue_UpdateStatsDone:
             mov   eax, edi
             lea   r10d, [r10+2*(r13+1)+1]


### PR DESCRIPTION
Three functional patches:
- Capture Stat Simplification
- Simplify some kingring penalties expressions
- Simplify away the PawnSet[] imbalance array (#1308)

bench: 5340212