### PR TITLE
A better contempt implementation

### DIFF
--- a/x86/Evaluate.asm
+++ b/x86/Evaluate.asm
@@ -617,10 +617,10 @@ KingSafetyDoneRet:
 	       test   edi, edi
 		 js   AllDone
 		mov   eax, edi
-		shr   eax, 4		    ; kingDanger>=0 here
+		shr   eax, 4		    ; kingDanger / 16
 		sub   esi, eax
-	       imul   edi, edi
-		shr   edi, 12
+	    imul   edi, edi         ; kingDanger * kingDanger
+		shr   edi, 12           ; previous / 4096
 		shl   edi, 16
 		sub   esi, edi
 
@@ -1532,6 +1532,8 @@ end virtual
 		jne   DoMaterialEval	; 0.87%
 .DoMaterialEvalReturn:
 	       imul   eax, 0x00010001
+		add   dword[.ei.score],	eax
+		mov eax, dword[ContemptScore]
 		add   dword[.ei.score],	eax
 	       test   ecx, ecx
 	;ProfileCond   nz, HaveSpecializedEval

--- a/x86/Evaluate_Init.asm
+++ b/x86/Evaluate_Init.asm
@@ -63,6 +63,8 @@ Evaluate_Init:
 		mov   ecx, 8*(6+6)
 	  rep movsd
 
+	    xor ecx,ecx
+		mov dword[ContemptScore], ecx  ; akin to StockFish's: "Score Eval::Contempt = SCORE_ZERO;"
 
 		lea   rdi, [KingFlank]
 		mov   rax, (FileABB or FileBBB or FileCBB or FileDBB)

--- a/x86/MainBss.asm
+++ b/x86/MainBss.asm
@@ -128,6 +128,8 @@ DoMaterialEval_Data:
 .QuadraticOurs:            rd 8*6
 .QuadraticTheirs:          rd 8*6
 QueenMinorsImbalance       rd 16
+ContemptScore              rd 1
+Reserved                   rd 1 ; explicitly pad to 64-bit alignment. Can be used.
 
 
 ;;;;;;;;;;;;;; data for endgames ;;;;;;;;;;;;;;

--- a/x86/SearchMacros.asm
+++ b/x86/SearchMacros.asm
@@ -35,6 +35,7 @@ macro search RootNode, PvNode
     .value		rd 1
     .evalu		rd 1
     .nullValue		rd 1
+    .valueDraw rd 1
     .futilityValue	rd 1
     .extension		rd 1
     .success		rd 1	; for tb
@@ -681,7 +682,7 @@ Display	2, "Search(alpha=%i1, beta=%i2,	depth=%i8, cutNode=%i9)	called%n"
 		lea   eax, [8*rax+rcx]
 		shl   eax, 6
 		mov   dword[.reductionOffset], eax
-		xor   eax, eax 
+		xor   eax, eax
 		mov   byte[.skipQuiets], al
 		mov   dword[.ttCapture], eax
 
@@ -1360,7 +1361,7 @@ Display	2, "Search(alpha=%i1, beta=%i2,	depth=%i8, cutNode=%i9)	called%n"
 	UpdateStats   r12d, .quietsSearched, dword[.quietCount], r11d, r10d, r15
 		jmp   .20Quiet_UpdateStatsDone
 .20Quiet_UpdateCaptureStats:
- UpdateCaptureStats   r12d, .capturesSearched, dword[.captureCount],	r11d, r10d
+		UpdateCaptureStats   r12d, .capturesSearched, dword[.captureCount],	r11d, r10d
 .20Quiet_UpdateStatsDone:
 		lea   r10d, [r10+2*(r13+1)+1]
     ; r10d = penalty
@@ -1368,29 +1369,30 @@ Display	2, "Search(alpha=%i1, beta=%i2,	depth=%i8, cutNode=%i9)	called%n"
 		jne   .20TTStore
 		cmp   byte[rbx+State.capturedPiece], 0
 		jne   .20TTStore
-	       imul   r11d,	r10d, -32
+		imul   r11d,	r10d, -32
 		cmp   r10d,	324
 		jae   .20TTStore
-      UpdateCmStats   (rbx-1*sizeof.State), r15, r11d, r10d, r8
+		UpdateCmStats   (rbx-1*sizeof.State), r15, r11d, r10d, r8
 		jmp   .20TTStore
 .20Mate:
+		mov dword[.valueDraw], VALUE_DRAW ; allows for cmovz later
 		mov   rax, qword[rbx+State.checkersBB]
-		mov   ecx, dword[rbp+Pos.sideToMove]
-	      movzx   edi, byte[rbx+State.ply]
-		sub   edi, VALUE_MATE
-	       test   rax, rax
-	      cmovz   edi, dword[DrawValue+4*rcx]
-	       test   r14d,	r14d
-	     cmovnz   edi, dword[.alpha]
-		jmp   .20TTStore
+		mov   ecx, dword[rbp+Pos.sideToMove]  ; the side getting mated
+		movzx edi, byte[rbx+State.ply]
+		sub   edi, VALUE_MATE ; game over
+		test  rax, rax
+		cmovz edi, dword[.valueDraw]
+		test   r14d, r14d
+		cmovnz edi, dword[.alpha]
+		jmp .20TTStore
 .20CheckBonus:
     ; we already checked that bestMove = 0
 		lea   edx, [r13-3*ONE_PLY]
-		 or   edx, esi
-		 js   .20TTStore
+		or   edx, esi
+		js   .20TTStore
 		cmp   byte[rbx+State.capturedPiece], 0
 		jne   .20TTStore
-	       imul   r11d,	r10d, 32
+		imul   r11d,	r10d, 32
 		cmp   r10d,	324
 		jae   .20TTStore
       UpdateCmStats   (rbx-1*sizeof.State),	r15, r11d, r10d, r8
@@ -1401,7 +1403,7 @@ Display	2, "Search(alpha=%i1, beta=%i2,	depth=%i8, cutNode=%i9)	called%n"
 		mov   r8, qword[.tte]
 		shr   r9, 48
 		mov   edx, edi
-	       test   r14d,	r14d
+		test   r14d, r14d
 		jnz   .ReturnBestValue
 		cmp   ecx, 2*VALUE_MATE_IN_MAX_PLY
 		jae   .20ValueToTT
@@ -1447,16 +1449,14 @@ Display	2, "Search returning %i0%n"
 	 calign   8
 .AbortSearch_PlyBigger:
 		mov   rcx, qword[rbx+State.checkersBB]
-		mov   eax, dword[rbp+Pos.sideToMove]
-		mov   eax, dword[DrawValue+4*rax]
-	       test   rcx, rcx
-		 jz   .Return
+		mov   eax, VALUE_DRAW
+	    test   rcx, rcx
+		jz   .Return
 	       call   Evaluate
 		jmp   .Return
 	 calign	  8
 .AbortSearch_PlySmaller:
-		mov   eax, dword[rbp+Pos.sideToMove]
-		mov   eax, dword[DrawValue+4*rax]
+		mov   eax, VALUE_DRAW
 		jmp   .Return
   end if
   if PvNode = 0

--- a/x86/Structs.asm
+++ b/x86/Structs.asm
@@ -82,6 +82,7 @@ struct EvalInfo
  kingAdjacentZoneAttacksCount rd 2
  score	   rd 1
 	   rd 1
+ contempt   rd 1
  me   rq 1
  pi   rq 1
 ends

--- a/x86/Think.asm
+++ b/x86/Think.asm
@@ -342,8 +342,7 @@ end if
 		mov   qword[.elapsed], rax
 
             xor  r10d, r10d
-            mov  edx, dword[rbp + Pos.sideToMove]
-            cmp  r12d, dword[DrawValue + 4*rdx]
+            cmp  r12d, VALUE_DRAW
             jne  @1f
             mov  ecx, dword[limits.time + 4*rdx]
             sub  ecx, eax
@@ -500,16 +499,25 @@ MainThread_Think:
 
 		mov   eax, dword[options.contempt]
 		cdq
-	       imul   eax, PawnValueEg
-		mov   ecx, 100
-	       idiv   ecx
-		mov   ecx, eax
+		imul  eax, PawnValueEg  ; options.contempt * PawnValueEg ---> [edx:eax]
+		mov   ecx, 100 
+		idiv  ecx               ; [edx:eax]/100 -->  EAX gets quotient, EDX gets remainder.
+		                        ; eax holds contempt value (ignore remainder in edx)
+		                        ; Next, we construct mg/eg contempt score
+		mov   ecx,eax           ; ecx represents mg value now (i.e., the contempt value just calculated)
+		shr   eax, 1            ; contempt / 2 => weaken the contempt for the endgame (eg value)
+		shl   ecx, 16           ; move mg contempt into upper 16 bits
+		add   ecx, eax          ; layer in eg value to get overall "Score"
+
 		mov   eax, dword[rbp+Pos.sideToMove]
+		test  eax,eax ;
+		jz   .save_contempt_score ; if white, save score as it currently is
+		
+		; black contempt scoring requires we negate the score first before saving it in ContemptScore
 		neg   ecx
-		mov   dword[DrawValue+4*rax], ecx
-		xor   eax, 1
-		neg   ecx
-		mov   dword[DrawValue+4*rax], ecx
+		
+.save_contempt_score:
+		mov dword[ContemptScore], ecx
 		add   byte[mainHash.date], 4
 
 if USE_WEAKNESS


### PR DESCRIPTION
The correct bench of this patch is 5466219. The original patch notes are incorrect.

Original patch: https://github.com/official-stockfish/Stockfish/commit/be382bb0cf5927dc10ff9be882f6980a78d1484a

Bench: 5466219