### PR TITLE
Realign bench of asmFish_base

### DIFF
--- a/x86/Pawn.asm
+++ b/x86/Pawn.asm
@@ -172,7 +172,13 @@ Neighbours_False:
 
 Continue:
         _popcnt   rax, r8, r9
-        _popcnt   r9, rbx, r10
+    if CPU_HAS_POPCNT = 1
+         popcnt   r9, rbx
+    else
+           push   r10             
+         _popcnt   r9, rbx, r10
+            pop   r10
+    end if
 
             neg   r11d
             neg   rbx


### PR DESCRIPTION
Now, base asm and matefinder executables should give bench 4777674.